### PR TITLE
fix: Inconsistent JVM-target compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,14 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+   compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+
+    kotlinOptions {
+        jvmTarget = '21'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes this error:
 `Execution failed for task ':webcontent_converter:compileDebugKotlin'.
Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (1.8) and 'compileDebugKotlin' (21).`
